### PR TITLE
Redirect catalogsearch/advanced to homepage

### DIFF
--- a/src/app/code/local/Omikron/Factfinder/controllers/CatalogSearch/AdvancedController.php
+++ b/src/app/code/local/Omikron/Factfinder/controllers/CatalogSearch/AdvancedController.php
@@ -1,0 +1,16 @@
+<?php
+require_once  Mage::getModuleDir('controllers', 'Mage_CatalogSearch'). DS .'AdvancedController.php';
+
+/**
+ * Class Omikron_Factfinder_CatalogSearch_AdvancedController
+ */
+class Omikron_Factfinder_CatalogSearch_AdvancedController extends Mage_CatalogSearch_AdvancedController
+{
+    /**
+     * Disable core advanced catalogsearch
+     */
+    public function indexAction()
+    {
+        $this->_redirect('/');
+    }
+}

--- a/src/app/code/local/Omikron/Factfinder/etc/config.xml
+++ b/src/app/code/local/Omikron/Factfinder/etc/config.xml
@@ -27,7 +27,7 @@
             <catalogsearch>
                 <args>
                     <modules>
-                        <factfinder before="Mage_CatalogSearch">Omikron_Factfinder_CatalogSearch</factfinder>
+                        <Omikron_Factfinder before="Mage_CatalogSearch">Omikron_Factfinder_CatalogSearch</Omikron_Factfinder>
                     </modules>
                 </args>
             </catalogsearch>


### PR DESCRIPTION
Disabling advanced catalogsearch functionality as this functionality is not integrated with Fact Finder. 
url catalogsearch/advanced redirect now to home page