### PR TITLE
FFWEB-915: Add possibility to export product final prices, including discounts

### DIFF
--- a/src/app/code/local/Omikron/Factfinder/Block/Adminhtml/System/Config/Button/TestConnection.php
+++ b/src/app/code/local/Omikron/Factfinder/Block/Adminhtml/System/Config/Button/TestConnection.php
@@ -29,7 +29,7 @@ class Omikron_Factfinder_Block_Adminhtml_System_Config_Button_TestConnection ext
      */
     public function getAjaxCheckUrl()
     {
-        return Mage::helper('adminhtml')->getUrl('factfinder/adminhtml_testconnection_testconnection/index');
+        return Mage::helper('adminhtml')->getUrl('factfinder/adminhtml_test_connection/index');
     }
 
     /**

--- a/src/app/code/local/Omikron/Factfinder/Helper/Product/Price.php
+++ b/src/app/code/local/Omikron/Factfinder/Helper/Product/Price.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Class Omikron_Factfinder_Helper_Product_Price
+ */
+class Omikron_Factfinder_Helper_Product_Price
+{
+    /**
+     * @param Mage_Catalog_Model_Product $product
+     * @param Mage_Core_Model_Store $store
+     * @param array $customerGroups
+     * @param callable $callback
+     * @return array
+     *
+     * @throws Mage_Core_Exception
+     */
+    public function collectPrices($product, $store, $customerGroups, $callback)
+    {
+        $prices =[];
+
+        if (!is_callable($callback)) {
+            throw new \http\Exception\InvalidArgumentException(__('Price calculation callback is not callable'));
+        }
+
+        foreach ($customerGroups as $group) {
+            $this->prepareStateForCatalogRuleProcessing($product);
+            $this->registerCatalogRuleData($group, $store);
+            $prices[$group] = $callback($product, $group);
+        }
+
+        return $prices;
+    }
+
+    /**
+     * @param int $customerGroup
+     * @param Mage_Core_Model_Store $store
+     * @throws Mage_Core_Exception
+     */
+    private function registerCatalogRuleData($customerGroup, $store)
+    {
+        Mage::register('rule_data', new Varien_Object(array(
+            'store_id'  => $store->getId(),
+            'website_id'  => $store->getWebsiteId(),
+            'customer_group_id' => $customerGroup,
+        )),true);
+    }
+
+    /**
+     * @param Mage_Catalog_Model_Product $product
+     */
+    private function prepareStateForCatalogRuleProcessing($product)
+    {
+        Mage::unregister('rule_data');
+        $product->unsetData('final_price');
+    }
+}

--- a/src/app/code/local/Omikron/Factfinder/Model/Source/CustomerGroup.php
+++ b/src/app/code/local/Omikron/Factfinder/Model/Source/CustomerGroup.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Class Omikron_Factfinder_Model_Source_CustomerGroup
+ */
+class Omikron_Factfinder_Model_Source_CustomerGroup
+{
+    /**
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return Mage::getResourceModel('customer/group_collection')->toOptionArray();
+    }
+}

--- a/src/app/code/local/Omikron/Factfinder/controllers/Adminhtml/Test/ConnectionController.php
+++ b/src/app/code/local/Omikron/Factfinder/controllers/Adminhtml/Test/ConnectionController.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Class Omikron_Factfinder_Adminhtml_Testconnection_TestconnectionController
+ * Class Omikron_Factfinder_Adminhtml_Test_ConnectionController
  */
-class Omikron_Factfinder_Adminhtml_Testconnection_TestconnectionController extends Mage_Adminhtml_Controller_Action
+class Omikron_Factfinder_Adminhtml_Test_ConnectionController extends Mage_Adminhtml_Controller_Action
 {
     /**
      * @var Omikron_Factfinder_Helper_Communication

--- a/src/app/code/local/Omikron/Factfinder/etc/config.xml
+++ b/src/app/code/local/Omikron/Factfinder/etc/config.xml
@@ -119,6 +119,7 @@
                 <ff_upload_port>21</ff_upload_port>
                 <ff_upload_path></ff_upload_path>
                 <ff_product_visibility>3,4</ff_product_visibility>
+                <ff_price_customer_group>0</ff_price_customer_group>
             </data_transfer>
         </factfinder>
     </default>

--- a/src/app/code/local/Omikron/Factfinder/etc/system.xml
+++ b/src/app/code/local/Omikron/Factfinder/etc/system.xml
@@ -523,6 +523,16 @@
                             <show_in_store>1</show_in_store>
                             <source_model>Omikron_Factfinder_Model_Source_Visibility</source_model>
                         </ff_product_visibility>
+                        <ff_price_customer_group translate="label comment">
+                            <label>Select Customer groups for price export</label>
+                            <comment>Diffrent prices for selected customer groups will be exported. To have specific prices displayed for proper customer groups You need also to have MultiPricesSearchCallback defined at Fact Finder</comment>
+                            <frontend_type>multiselect</frontend_type>
+                            <sort_order>3</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <source_model>Omikron_Factfinder_Model_Source_CustomerGroup</source_model>
+                        </ff_price_customer_group>
                     </fields>
                 </data_transfer>
                 <ftp_data_transfer translate="label comment">

--- a/src/app/locale/en_US/Omikron_Factfinder.csv
+++ b/src/app/locale/en_US/Omikron_Factfinder.csv
@@ -135,4 +135,4 @@
 "Basic Auth password","Basic Auth password"
 "Select Product Visibility","Select Product Visibility"
 "Visibility attribute values used in filtering prodcut collection.","Visibility attribute values used in filtering prodcut collection."
-
+"Price calculation callback is not callable","Price calculation callback is not callable"


### PR DESCRIPTION

- Solves issue: 
 Getting only base price of products, allow user to export prices for different customer groups as multi attribute
- Description: 
This fix changes price obtain mechanism by  respecting catalog rules applied to given product at the time feed file is exported. 
User is able to choose which customer group price should be exported. If multiple customer groups is selected, prices will be exported as multiattribute (i.e |0=234.00|1=249.00|7=2.60| where 0,1,7 are customer group ids)

- Tested with Magento editions/versions: 
1.9.2.1
- Tested with PHP versions: 
5.6, 7,2
