### PR TITLE
Added `special_price` to selected products attribute collection by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,20 +1,21 @@
 # v0.9-beta.4
 ## FIX
-- Emulating `adminhtml` area in `factfinder_export.php` shell script in order to execute `processAdminFinalPrice` observer of event `catalog_product_get_final_price`
+- added `special_price` to selected products attribute collection by default
+- emulating `adminhtml` area in `factfinder_export.php` shell script in order to execute `processAdminFinalPrice` observer of event `catalog_product_get_final_price`
 
 # v0.9-beta.3
 ## Change
-- Upgraded FACT-Finder WebComponents to version 1.2.14
+- upgraded FACT-Finder WebComponents to version 1.2.14
 
 ## ADD
-- Adds possibility to configure frequency of feed file generation by Cron
+- added possibility to configure frequency of feed file generation by Cron
 
 # v0.9-beta.2
 ## CHANGE
-- add `unresolved` attribute to all components html in order to prevent rendering it before transformation into functional web components
+- added `unresolved` attribute to all components html in order to prevent rendering it before transformation into functional web components
 
 ## ADD
-- Added possibility to choose which customer group prices have to be selected at product export. By default is `non logged`
+- added possibility to choose which customer group prices have to be selected at product export. By default is `non logged`
 
 
 # v0.9-beta.1

--- a/src/app/code/local/Omikron/Factfinder/Helper/Product.php
+++ b/src/app/code/local/Omikron/Factfinder/Helper/Product.php
@@ -315,6 +315,7 @@ class Omikron_Factfinder_Helper_Product extends Mage_Core_Helper_Abstract
             'thumbnail',
             'image',
             'price',
+            'special_price',
             'manufacturer',
             'visibility'
         ];


### PR DESCRIPTION
- Solves issue: 
Special price was not included by default as selected product collection attribute. If `special_price` was not selected as one of additional attribute, `getFinalPrice` method returns product base price, 
without taking special price into account
- Tested with Magento editions/versions: 
1.9.2.1, 1.9.3.8
- Tested with PHP versions: 
5.6