### PR TITLE
Emulating `adminhtml` area in `factfinder_export.php` 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# v0.9-beta.4
+## FIX
+- Emulating `adminhtml` area in `factfinder_export.php` shell script in order to execute `processAdminFinalPrice` observer of event `catalog_product_get_final_price`
+
 # v0.9-beta.3
 ## Change
 - Upgraded FACT-Finder WebComponents to version 1.2.14

--- a/shell/factfinder_export.php
+++ b/shell/factfinder_export.php
@@ -50,10 +50,15 @@ USAGE;
      */
     private function exportStore($storeId, $filename)
     {
+        /** @var Mage_Core_Model_App_Emulation $appEmulation */
+        $appEmulation = Mage::getSingleton('core/app_emulation');
+        $initialEnvironmentInfo = $appEmulation->startEnvironmentEmulation($storeId, Mage_Core_Model_App_Area::AREA_ADMINHTML);
+        Mage::app()->addEventArea(Mage_Core_Model_App_Area::AREA_ADMINHTML);
         $store = Mage::getModel('core/store')->load($storeId);
         /** @var Omikron_Factfinder_Model_Export_Product $exporter */
         $exporter = Mage::getModel('Omikron_Factfinder_Model_Export_Product');
         $exporter->exportProduct($store, $filename);
+        $appEmulation->stopEnvironmentEmulation($initialEnvironmentInfo);
 
         printf("Successfully generated export to: %s\n", $filename);
     }


### PR DESCRIPTION
- Description: 
Emulating `adminhtml` area in `factfinder_export.php` shell script in order to execute `processAdminFinalPrice` observer of event `catalog_product_get_final_price`
- Tested with Magento editions/versions: 
1.9.2.1
- Tested with PHP versions: 
5.6