### PR TITLE
Prevents removing decimal separators in `Attributes` column

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# v0.9-beta.5
+## FIX
+-  prevents decimal values in `Attributes` column to have their decimal separators removed
+
 # v0.9-beta.4
 ## FIX
 - added `special_price` to selected products attribute collection by default

--- a/src/app/code/local/Omikron/Factfinder/Helper/Product.php
+++ b/src/app/code/local/Omikron/Factfinder/Helper/Product.php
@@ -473,6 +473,9 @@ class Omikron_Factfinder_Helper_Product extends Mage_Core_Helper_Abstract
      */
     private function cleanValue($value, $isMultiAttributeValue = false)
     {
+        if (is_numeric($value)) {
+            return $value;
+        }
         $value = strip_tags(nl2br($value));
         $value = preg_replace("/\r|\n/", "", $value);
         $value = addcslashes($value, '\\');


### PR DESCRIPTION
- Solves issue: 
prevents decimal values in `Attributes` column to have their decimal separators removed
- Description: 
- Tested with Magento editions/versions: 
1.9.3.8
- Tested with PHP versions: 
5.6.2