### PR TITLE
FFWEB-1007 : Remove 'keep-filter' parameter from module configuration

### DIFF
--- a/src/app/code/local/Omikron/Factfinder/Helper/Data.php
+++ b/src/app/code/local/Omikron/Factfinder/Helper/Data.php
@@ -33,7 +33,6 @@ class Omikron_Factfinder_Helper_Data extends Mage_Core_Helper_Abstract
     const PATH_DEFAULT_QUERY = 'factfinder/advanced/default_query';
     const PATH_ADD_PARAMS = 'factfinder/advanced/add_params';
     const PATH_ADD_TRACKING_PARAMS = 'factfinder/advanced/add_tracking_params';
-    const PATH_KEEP_FILTERS = 'factfinder/advanced/keep_filters';
     const PATH_KEEP_URL_PARAMS = 'factfinder/advanced/keep_url_param';
     const PATH_USE_ASN = 'factfinder/advanced/use_asn';
     const PATH_USE_FOUND_ROWS = 'factfinder/advanced/use_found_words';
@@ -260,15 +259,6 @@ class Omikron_Factfinder_Helper_Data extends Mage_Core_Helper_Abstract
     public function getAddTrackingParams()
     {
         return Mage::getStoreConfig(self::PATH_ADD_TRACKING_PARAMS);
-    }
-
-    /**
-     * Returns the keep-filters configuration
-     * @return bool
-     */
-    public function getKeepFilters()
-    {
-        return boolval(Mage::getStoreConfig(self::PATH_KEEP_FILTERS));
     }
 
     /**

--- a/src/app/code/local/Omikron/Factfinder/etc/config.xml
+++ b/src/app/code/local/Omikron/Factfinder/etc/config.xml
@@ -101,7 +101,6 @@
                 <use_url_parameter>1</use_url_parameter>
                 <use_cache>0</use_cache>
                 <default_query>*</default_query>
-                <keep_filters>0</keep_filters>
                 <use_asn>1</use_asn>
                 <use_found_words>0</use_found_words>
                 <use_campaigns>1</use_campaigns>

--- a/src/app/code/local/Omikron/Factfinder/etc/system.xml
+++ b/src/app/code/local/Omikron/Factfinder/etc/system.xml
@@ -244,16 +244,6 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </add_tracking_params>
-                        <keep_filters translate="label comment">
-                            <label>Keep filters</label>
-                            <comment>With this property you can determine if filters (which where set before the search, e.g. via ASN) should be kept or discarded.</comment>
-                            <frontend_type>select</frontend_type>
-                            <sort_order>7</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                        </keep_filters>
                         <keep_url_params translate="label comment">
                             <label>Keep url params</label>
                             <comment>Determines if parameters which are written into the URL should be kept.</comment>

--- a/src/app/design/frontend/base/default/template/factfinder/communication/communication.phtml
+++ b/src/app/design/frontend/base/default/template/factfinder/communication/communication.phtml
@@ -18,9 +18,6 @@ $dataHelper = Mage::helper('factfinder/data');
         default-query="<?php echo $dataHelper->getDefaultQuery(); ?>"
         add-params="<?php echo $dataHelper->getAddParams(); ?>"
         add-tracking-params="<?php echo $dataHelper->getAddTrackingParams(); ?>"
-        <?php if($dataHelper->getKeepFilters()) {
-            echo 'keep-filters';
-        } ?>
         keep-url-params="<?php echo $dataHelper->getKeepUrlParams(); ?>"
         use-asn="<?php echo $dataHelper->getUseAsn() ? 'true' : 'false' ?>"
         use-found-rows="<?php echo $dataHelper->getUseFoundWords() ? 'true' : 'false' ?>"


### PR DESCRIPTION
- Solves issue: 
- Removed possibility to set 'keep-filters' parameter as it cause 401 response when there are filter values with encoded special characters
- Tested with Magento editions/versions: 
1.9.3.8
- Tested with PHP versions: 
5.6
