### PR TITLE
FFWEB-1014 : Fixes to external url export

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+# v0.9-beta.6
+## FIX
+-  Fixed password validation in external url feed export available at /factfinder/export
+-  Fixed upload feed file functionality in module confiuration
+
+##CHANGE
+- Set ftp user password backend model to adminhtml/system_config_backend_encrypted. IMPORTANT! Re-entering the ftp password in the module configuration is required
+
 # v0.9-beta.5
 ## FIX
 -  prevents decimal values in `Attributes` column to have their decimal separators removed

--- a/src/app/code/local/Omikron/Factfinder/Helper/Upload.php
+++ b/src/app/code/local/Omikron/Factfinder/Helper/Upload.php
@@ -33,13 +33,13 @@ class Omikron_Factfinder_Helper_Upload extends Mage_Core_Helper_Abstract
                 $ftp = new Varien_Io_Ftp();
                 $ftp->open(
                     [
-                        'host' => $this->getConfig(self::PATH_FF_UPLOAD_HOST),
-                        'user' => $this->getConfig(self::PATH_FF_UPLOAD_USER),
+                        'host'     => $this->getConfig(self::PATH_FF_UPLOAD_HOST),
+                        'user'     => $this->getConfig(self::PATH_FF_UPLOAD_USER),
                         'password' => $this->getConfig(self::PATH_FF_UPLOAD_PASSWORD),
-                        'ssl' => true,
-                        'passive' => true,
-                        'port' => $this->getConfig(self::PATH_FF_UPLOAD_PORT),
-                        'path' => $this->getConfig(self::PATH_FF_UPLOAD_PATH)
+                        'ssl'      => true,
+                        'passive'  => true,
+                        'port'     => $this->getConfig(self::PATH_FF_UPLOAD_PORT),
+                        'path'     => $this->getConfig(self::PATH_FF_UPLOAD_PATH)
                     ]
                 );
                 $ftp->write($destinationPath, $content);

--- a/src/app/code/local/Omikron/Factfinder/controllers/ExportController.php
+++ b/src/app/code/local/Omikron/Factfinder/controllers/ExportController.php
@@ -14,7 +14,7 @@ class Omikron_Factfinder_ExportController extends Mage_Core_Controller_Front_Act
 
         $hasSuppliedCredentials = !(empty($_SERVER['PHP_AUTH_USER']) && empty($_SERVER['PHP_AUTH_PW']));
 
-        $validated = ($hasSuppliedCredentials && in_array($_SERVER['PHP_AUTH_USER'], $validUsers)) && (md5($_SERVER['PHP_AUTH_PW']) == $validPasswords[$_SERVER['PHP_AUTH_USER']]);
+        $validated = ($hasSuppliedCredentials && in_array($_SERVER['PHP_AUTH_USER'], $validUsers)) && (Mage::helper('core')->encrypt($_SERVER['PHP_AUTH_PW']) == $validPasswords[$_SERVER['PHP_AUTH_USER']]);
 
         if (!$validated) {
             header('WWW-Authenticate: Basic realm="' . self::REALM . '"');

--- a/src/app/code/local/Omikron/Factfinder/controllers/ExportController.php
+++ b/src/app/code/local/Omikron/Factfinder/controllers/ExportController.php
@@ -7,14 +7,13 @@ class Omikron_Factfinder_ExportController extends Mage_Core_Controller_Front_Act
     public function indexAction()
     {
         /** @var Omikron_Factfinder_Helper_Data $helper */
-        $helper = Mage::helper('factfinder/data');
-
-        $validPasswords = array($helper->getUploadUrlUser() => $helper->getUploadUrlPassword());
-        $validUsers = array_keys($validPasswords);
-
+        $helper                 = Mage::helper('factfinder/data');
+        $validPasswords         = array($helper->getUploadUrlUser() => $helper->getUploadUrlPassword());
+        $validUsers             = array_keys($validPasswords);
         $hasSuppliedCredentials = !(empty($_SERVER['PHP_AUTH_USER']) && empty($_SERVER['PHP_AUTH_PW']));
 
-        $validated = ($hasSuppliedCredentials && in_array($_SERVER['PHP_AUTH_USER'], $validUsers)) && (Mage::helper('core')->encrypt($_SERVER['PHP_AUTH_PW']) == $validPasswords[$_SERVER['PHP_AUTH_USER']]);
+        $validated = ($hasSuppliedCredentials && in_array($_SERVER['PHP_AUTH_USER'], $validUsers)) &&
+            strcmp($_SERVER['PHP_AUTH_PW'], $validPasswords[$_SERVER['PHP_AUTH_USER']]) === 0;
 
         if (!$validated) {
             header('WWW-Authenticate: Basic realm="' . self::REALM . '"');

--- a/src/app/code/local/Omikron/Factfinder/etc/config.xml
+++ b/src/app/code/local/Omikron/Factfinder/etc/config.xml
@@ -130,6 +130,9 @@
             <ftp_data_transfer>
                 <ff_upload_password backend_model="adminhtml/system_config_backend_encrypted"/>
             </ftp_data_transfer>
+            <basic_auth_data_transfer>
+                <ff_upload_url_password backend_model ="adminhtml/system_config_backend_encrypted"/>
+            </basic_auth_data_transfer>
         </factfinder>
     </default>
     <crontab>

--- a/src/app/code/local/Omikron/Factfinder/etc/config.xml
+++ b/src/app/code/local/Omikron/Factfinder/etc/config.xml
@@ -127,6 +127,9 @@
                 <ff_product_visibility>3,4</ff_product_visibility>
                 <ff_price_customer_group>0</ff_price_customer_group>
             </data_transfer>
+            <ftp_data_transfer>
+                <ff_upload_password backend_model="adminhtml/system_config_backend_encrypted"/>
+            </ftp_data_transfer>
         </factfinder>
     </default>
     <crontab>

--- a/src/app/code/local/Omikron/Factfinder/etc/system.xml
+++ b/src/app/code/local/Omikron/Factfinder/etc/system.xml
@@ -576,6 +576,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
+                            <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
                         </ff_upload_password>
                         <ff_create_feed translate="label comment">
                             <label>Generate and upload export file</label>

--- a/src/app/design/adminhtml/default/default/template/factfinder/system/config/button/upload.phtml
+++ b/src/app/design/adminhtml/default/default/template/factfinder/system/config/button/upload.phtml
@@ -7,7 +7,7 @@
                 setUploadCsvMessage(response.message.message);
             },
             onFailure: function (transport) {
-                setUploadCsvMessage("<?php echo(__("There were an error during feed upload. Please check the server log and contact the technical support.")) ?>");
+                setUploadCsvMessage('<?php echo $this->jsQuoteEscape($this->__('There were an error during feed upload. Please check the server log and contact the technical support.')) ?>');
             }
         });
     }

--- a/src/app/design/adminhtml/default/default/template/factfinder/system/config/button/upload.phtml
+++ b/src/app/design/adminhtml/default/default/template/factfinder/system/config/button/upload.phtml
@@ -7,7 +7,7 @@
                 setUploadCsvMessage(response.message.message);
             },
             onFailure: function (transport) {
-                setUploadCsvMessage(<?php echo(__("There were an error during feed upload. Please check the server log and contact the technical support.")) ?>);
+                setUploadCsvMessage("<?php echo(__("There were an error during feed upload. Please check the server log and contact the technical support.")) ?>");
             }
         });
     }


### PR DESCRIPTION
- Solves issue: 
Fixed external url export, by changing basic auth user/password validation
Fixed uploading feed file from admin panel, using "Upload export file(s) now" button
Change FTP password to be encrypted
- Tested with Magento editions/versions: 
1.9.3.8
- Tested with PHP versions: 
5.6
