### PR TITLE
Update Communication.php

### DIFF
--- a/src/app/code/community/Omikron/Factfinder/Helper/Communication.php
+++ b/src/app/code/community/Omikron/Factfinder/Helper/Communication.php
@@ -58,7 +58,8 @@ class Omikron_Factfinder_Helper_Communication extends Mage_Core_Helper_Abstract
         // Send HTTP GET with curl
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_URL, $url);
-        curl_setopt($curl, CURLOPT_ENCODING, 'Accept-encoding: gzip, deflate');
+        // Special value '' for all supported encoding types.
+        curl_setopt($curl, CURLOPT_ENCODING, '');
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
 
         // Receive server response


### PR DESCRIPTION
Fix wrong value for CURLOPT_ENCODING and add support for all encoding types.

- Description:

The complete header was set for the CURLOPT_ENCODING.

- Tested with Magento editions/versions: 

1.9.4.1 Community Edition

- Tested with PHP versions: 

7.1.30
