### PR TITLE
FFWEB-1604: Add recommendation push import type

### DIFF
--- a/src/app/code/community/Omikron/Factfinder/Model/Api/Ng/PushImport.php
+++ b/src/app/code/community/Omikron/Factfinder/Model/Api/Ng/PushImport.php
@@ -31,7 +31,7 @@ class Omikron_Factfinder_Model_Api_Ng_PushImport implements Omikron_Factfinder_M
         ];
 
         $response = [];
-        $importTypes = explode('', Mage::getStoreConfig('factfinder/data_transfer/ff_push_import_types', $scopeId));
+        $importTypes = explode(',', Mage::getStoreConfig('factfinder/data_transfer/ff_push_import_types', $scopeId));
         $endpoint = $this->communicationConfig->getAddress() . sprintf('/rest/%s/import', $this->communicationConfig->getApi());
         foreach ($importTypes as $type) {
             $response = array_merge_recursive($response, $this->apiClient->post($endpoint . "/$type", $params));

--- a/src/app/code/community/Omikron/Factfinder/Model/Api/Ng/PushImport.php
+++ b/src/app/code/community/Omikron/Factfinder/Model/Api/Ng/PushImport.php
@@ -31,8 +31,9 @@ class Omikron_Factfinder_Model_Api_Ng_PushImport implements Omikron_Factfinder_M
         ];
 
         $response = [];
+        $importTypes = explode('', Mage::getStoreConfig('factfinder/data_transfer/ff_push_import_types', $scopeId));
         $endpoint = $this->communicationConfig->getAddress() . sprintf('/rest/%s/import', $this->communicationConfig->getApi());
-        foreach (['data', 'suggest'] as $type) {
+        foreach ($importTypes as $type) {
             $response = array_merge_recursive($response, $this->apiClient->post($endpoint . "/$type", $params));
         }
 

--- a/src/app/code/community/Omikron/Factfinder/Model/Api/PushImport.php
+++ b/src/app/code/community/Omikron/Factfinder/Model/Api/PushImport.php
@@ -39,7 +39,7 @@ class Omikron_Factfinder_Model_Api_PushImport implements Omikron_Factfinder_Mode
         ];
 
         $response = [];
-        $importTypes = explode('', Mage::getStoreConfig('factfinder/data_transfer/ff_push_import_types', $scopeId));
+        $importTypes = explode(',', Mage::getStoreConfig('factfinder/data_transfer/ff_push_import_types', $scopeId));
         $endpoint = $this->communicationConfig->getAddress() . '/' . $this->apiName;
         foreach ($importTypes as $type) {
             $params['type'] = $type;

--- a/src/app/code/community/Omikron/Factfinder/Model/Api/PushImport.php
+++ b/src/app/code/community/Omikron/Factfinder/Model/Api/PushImport.php
@@ -39,8 +39,9 @@ class Omikron_Factfinder_Model_Api_PushImport implements Omikron_Factfinder_Mode
         ];
 
         $response = [];
+        $importTypes = explode('', Mage::getStoreConfig('factfinder/data_transfer/ff_push_import_types', $scopeId));
         $endpoint = $this->communicationConfig->getAddress() . '/' . $this->apiName;
-        foreach (['data','suggest'] as $type) {
+        foreach ($importTypes as $type) {
             $params['type'] = $type;
             $response       = array_merge_recursive($response, $this->apiClient->sendRequest($endpoint, $params));
         }

--- a/src/app/code/community/Omikron/Factfinder/Model/Source/ImportTypes.php
+++ b/src/app/code/community/Omikron/Factfinder/Model/Source/ImportTypes.php
@@ -1,7 +1,5 @@
 <?php
 
-use Mage_Eav_Model_Entity_Attribute as Attribute;
-
 class Omikron_Factfinder_Model_Source_ImportTypes
 {
     /**

--- a/src/app/code/community/Omikron/Factfinder/Model/Source/ImportTypes.php
+++ b/src/app/code/community/Omikron/Factfinder/Model/Source/ImportTypes.php
@@ -1,0 +1,27 @@
+<?php
+
+use Mage_Eav_Model_Entity_Attribute as Attribute;
+
+class Omikron_Factfinder_Model_Source_ImportTypes
+{
+    /**
+     * @return array
+     */
+    public function toOptionArray()
+    {
+        return [
+            [
+                'value' => 'data',
+                'label' => 'Data'
+            ],
+            [
+                'value' => 'suggest',
+                'label' => 'Suggest'
+            ],
+            [
+                'value' => 'recommendation',
+                'label' => 'Recommendation'
+            ],
+        ];
+    }
+}

--- a/src/app/code/community/Omikron/Factfinder/etc/config.xml
+++ b/src/app/code/community/Omikron/Factfinder/etc/config.xml
@@ -138,6 +138,7 @@
                 <ff_image_resize_width>200</ff_image_resize_width>
                 <ff_image_resize_height>200</ff_image_resize_height>
                 <ff_push_import_enabled>0</ff_push_import_enabled>
+                <ff_push_import_types>data</ff_push_import_types>
             </data_transfer>
             <ftp_data_transfer>
                 <ff_upload_password backend_model="adminhtml/system_config_backend_encrypted" />

--- a/src/app/code/community/Omikron/Factfinder/etc/system.xml
+++ b/src/app/code/community/Omikron/Factfinder/etc/system.xml
@@ -537,6 +537,15 @@
                             <show_in_store>1</show_in_store>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                         </ff_push_import_enabled>
+                        <ff_push_import_types>
+                            <label>Pushed import types</label>
+                            <sort_order>10</sort_order>
+                            <frontend_type>multiselect</frontend_type>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <source_model>factfinder/source_importTypes</source_model>
+                        </ff_push_import_types>
                     </fields>
                 </data_transfer>
                 <ftp_data_transfer translate="label comment">


### PR DESCRIPTION
- Description: 
 Added possibility to choose data type imports for  (available data, suggest , recommendation)
- Tested with Magento editions/versions: 
1.9.3.8
- Tested with PHP versions: 
7.2
