### PR TITLE
FFWEB-2094: Encode parameters before converting them to parameter string

### DIFF
--- a/src/js/factfinder/search-redirect.js
+++ b/src/js/factfinder/search-redirect.js
@@ -4,7 +4,7 @@ document.addEventListener('ffReady', function () {
     document.addEventListener('before-search', function (event) {
         if (['productDetail', 'getRecords'].lastIndexOf(event.detail.type) === -1) {
             event.preventDefault();
-            window.location = redirectPath + factfinder.common.dictToParameterString(event.detail);
+            window.location = redirectPath + factfinder.common.dictToParameterString(factfinder.common.encodeDict(event.detail));
         }
     });
 


### PR DESCRIPTION
- Solves issue: 
FFEWEB-2094
- Description: 
Encode search querty before sending it on BE
- Tested with Magento editions/versions: 
1.9.3.8
- Tested with PHP versions: 
7.4.3

